### PR TITLE
Improve stubs and example

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install build
+      - run: python -m build --sdist --wheel
+      - uses: pypa/gh-action-pypi-publish@v1
+        with:
+          password: '${{ secrets.PYPI_TOKEN }}'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,16 @@
+name: Validate
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+.PHONY: test clean
+
+VENV=.venv
+PYTHON=$(VENV)/bin/python
+PIP=$(VENV)/bin/pip
+MYPY=$(VENV)/bin/mypy
+
+$(VENV):
+	python3 -m venv $(VENV)
+	$(PIP) install --upgrade pip mypy
+
+clean:
+	rm -rf $(VENV)
+	rm -rf .mypy_cache
+
+install: $(VENV)
+	$(PIP) install defopt
+	$(PIP) install .
+
+# Run mypy on stubs and example script
+mypy: install
+	$(MYPY) --strict --package defopt tests/test_script.py
+
+test: mypy
+	$(PYTHON) tests/test_script.py 42 --times 1

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# types-defopt
+
+Typing stubs for the [defopt](https://github.com/anntzer/defopt) package.
+
+These stubs provide type hints for the runtime library, which does not
+ship with annotations. Only the minimal API used by typical scripts is
+covered. Contributions to improve coverage are welcome.
+
+## Installation
+
+```
+pip install types-defopt
+```
+
+## Development
+
+Stubs are located under `stubs/defopt`. Use the provided `Makefile`
+to validate them within an isolated environment:
+
+```
+make test
+```
+
+This creates a virtual environment, installs the runtime library and the
+stubs, and then type-checks both the stubs and an example script. The CI
+workflow performs the same check.
+
+## Publishing
+
+Releases are automated via GitHub Actions. Create a git tag starting
+with `v` (e.g. `v0.1.0`) and push it to trigger a PyPI upload. A
+`PYPI_TOKEN` secret must be configured in the repository settings.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["setuptools>=61", "setuptools_scm[toml]>=6.4"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "types-defopt"
+dynamic = ["version"]
+authors = [{name="Daniel Pope", email=""}]
+description = "Typing stubs for the defopt package"
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.8"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Stubs Only",
+]
+
+[tool.setuptools.package-data]
+"defopt" = ["py.typed", "*.pyi"]
+
+[tool.setuptools.packages.find]
+where = ["stubs"]
+namespaces = false
+
+[tool.mypy]
+python_version = "3.8"
+strict = true
+
+[tool.setuptools_scm]
+

--- a/stubs/defopt/__init__.pyi
+++ b/stubs/defopt/__init__.pyi
@@ -1,0 +1,50 @@
+from typing import Any, Callable, Dict, List, Optional, Union, Literal, Tuple
+
+Funcs = Union[Callable[..., Any], List[Callable[..., Any]], Dict[str, "Funcs"]]
+
+__version__: str
+
+def run(
+    funcs: Funcs,
+    *,
+    parsers: Dict[type, Callable[[str], Any]] = ..., 
+    short: Optional[Dict[str, str]] = ..., 
+    cli_options: Literal["kwonly", "all", "has_default"] = ..., 
+    show_defaults: bool = ..., 
+    show_types: bool = ..., 
+    no_negated_flags: bool = ..., 
+    version: Union[str, None, bool] = ..., 
+    argparse_kwargs: dict = ..., 
+    intermixed: bool = ..., 
+    argv: Optional[List[str]] = ...,
+) -> Any: ...
+
+def bind(
+    funcs: Funcs,
+    *,
+    parsers: Dict[type, Callable[[str], Any]] = ...,
+    short: Optional[Dict[str, str]] = ..., 
+    cli_options: Literal["kwonly", "all", "has_default"] = ..., 
+    show_defaults: bool = ..., 
+    show_types: bool = ..., 
+    no_negated_flags: bool = ..., 
+    version: Union[str, None, bool] = ..., 
+    argparse_kwargs: dict = ..., 
+    intermixed: bool = ..., 
+    argv: Optional[List[str]] = ...,
+) -> Callable[[], Any]: ...
+
+def bind_known(
+    funcs: Funcs,
+    *,
+    parsers: Dict[type, Callable[[str], Any]] = ...,
+    short: Optional[Dict[str, str]] = ..., 
+    cli_options: Literal["kwonly", "all", "has_default"] = ..., 
+    show_defaults: bool = ..., 
+    show_types: bool = ..., 
+    no_negated_flags: bool = ..., 
+    version: Union[str, None, bool] = ..., 
+    argparse_kwargs: dict = ..., 
+    intermixed: bool = ..., 
+    argv: Optional[List[str]] = ...,
+) -> Tuple[Callable[[], Any], List[str]]: ...

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,0 +1,23 @@
+from defopt import run, bind, bind_known
+
+
+def main(value: int, *, times: int = 1) -> None:
+    """Print a value multiple times.
+
+    :param value: Value to display
+    :param times: Number of repetitions
+    """
+    for _ in range(times):
+        print(value)
+
+
+def demo_bind() -> None:
+    call = bind(main, argv=["1", "--times", "2"])
+    call()
+    call2, rest = bind_known(main, argv=["2", "--times", "3"])
+    call2()
+
+
+if __name__ == "__main__":
+    demo_bind()
+    run(main)


### PR DESCRIPTION
## Summary
- link README to the correct defopt repo
- use setuptools_scm for versioning
- check installed package in `make test` and execute the sample script
- provide detailed stubs for `run`, `bind`, and `bind_known`
- update the example script to the documented API

## Testing
- `make test` *(fails: Could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685e336d29a48328a6566a489df5cb89