### PR TITLE
Switch to uv for dependency management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,17 @@
-.PHONY: test clean
 
-VENV=.venv
-PYTHON=$(VENV)/bin/python
-PIP=$(VENV)/bin/pip
-MYPY=$(VENV)/bin/mypy
+.PHONY: test clean sync
 
-$(VENV):
-	python3 -m venv $(VENV)
-	$(PIP) install --upgrade pip mypy
+PYTHON=python3
+MYPY=mypy
 
 clean:
-	rm -rf $(VENV)
 	rm -rf .mypy_cache
 
-install: $(VENV)
-	$(PIP) install defopt
-	$(PIP) install .
+sync:
+	uv sync --active --group dev --offline --no-install-package mypy
 
 # Run mypy on stubs and example script
-mypy: install
+mypy: sync
 	$(MYPY) --strict --package defopt tests/test_script.py
 
 test: mypy

--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@ pip install types-defopt
 ## Development
 
 Stubs are located under `stubs/defopt`. Use the provided `Makefile`
-to validate them within an isolated environment:
+and `uv` to validate them:
 
 ```
 make test
 ```
 
-This creates a virtual environment, installs the runtime library and the
-stubs, and then type-checks both the stubs and an example script. The CI
-workflow performs the same check.
+`make test` runs `uv sync` to install development dependencies and the
+runtime library before type-checking the stubs and an example script.
+The CI workflow performs the same check.
 
 ## Publishing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "types-defopt"
 dynamic = ["version"]
-authors = [{name="Daniel Pope", email=""}]
+authors = [{name="Daniel Pope"}]
 description = "Typing stubs for the defopt package"
 readme = "README.md"
 license = {text = "MIT"}
@@ -28,4 +28,7 @@ python_version = "3.8"
 strict = true
 
 [tool.setuptools_scm]
+
+[dependency-groups]
+dev = ["mypy"]
 


### PR DESCRIPTION
## Summary
- use `uv sync` instead of manual virtualenv
- document the new workflow
- add `dependency-groups` table to declare dev dependencies
- fix project metadata so uv build passes

## Testing
- `make test` *(fails: No solution found when resolving dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685e56d5e04883289647ffd29a212df6