### PR TITLE
Add defopt signature stub

### DIFF
--- a/stubs/defopt-stubs/__init__.pyi
+++ b/stubs/defopt-stubs/__init__.pyi
@@ -1,3 +1,5 @@
+import types
+import inspect
 from typing import Callable, Dict, List, Optional, Union, Literal, Tuple
 
 type Funcs[T] = Callable[..., T] | List[Callable[..., T]] | Dict[str, Funcs[T]]
@@ -49,3 +51,29 @@ def bind_known[T](
     intermixed: bool = ..., 
     argv: Optional[List[str]] = ...,
 ) -> Tuple[Callable[[], T], List[str]]: ...
+class Parameter(inspect.Parameter):
+    doc: Optional[str]
+    def replace(
+        self,
+        *,
+        doc: Optional[str] = ...,
+        **kwargs: object,
+    ) -> "Parameter": ...
+
+class Signature(inspect.Signature):
+    doc: Optional[str]
+    raises: Tuple[type[BaseException], ...]
+
+    @property
+    def parameters(self) -> types.MappingProxyType[str, Parameter]: ...
+
+    def replace(
+        self,
+        *,
+        doc: Optional[str] = ...,
+        raises: Tuple[type[BaseException], ...] = ...,
+        **kwargs: object,
+    ) -> "Signature": ...
+
+
+def signature(func: Callable[..., object] | str) -> Signature: ...

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,4 +1,4 @@
-from defopt import run, bind, bind_known
+from defopt import run, bind, bind_known, signature
 
 
 def main(value: int, *, times: int = 1) -> int:
@@ -20,6 +20,13 @@ def demo_bind() -> None:
     ret2: int = call2()
 
 
+def demo_signature() -> None:
+    sig = signature(main)
+    doc: str | None = sig.doc
+    param_doc: str | None = sig.parameters["value"].doc
+
+
 if __name__ == "__main__":
     demo_bind()
+    demo_signature()
     res: int = run(main)


### PR DESCRIPTION
## Summary
- stub defopt.signature and Signature in the types package
- test calling signature in the example script

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6889d5c893748328b9fcc1de00527fba