### PR TITLE
Improve release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,15 +8,17 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v6
-      - run: pip install build
-      - run: python -m build --sdist --wheel
+      - run: uvx --from=build pyproject-build --sdist --wheel
       - uses: pypa/gh-action-pypi-publish@v1
-        with:
-          password: '${{ secrets.PYPI_TOKEN }}'


### PR DESCRIPTION
## Summary
- update release workflow to fetch all git history
- run pyproject-build with uvx and skip the PyPI token secret
- add id-token write permissions for trusted publishing

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688bd8b530b48328af6775776cec807b