### PR TITLE
Use covariant collections in defopt stubs

### DIFF
--- a/stubs/defopt-stubs/__init__.pyi
+++ b/stubs/defopt-stubs/__init__.pyi
@@ -1,8 +1,8 @@
 import types
 import inspect
-from typing import Callable, Dict, List, Optional, Union, Literal, Tuple
+from typing import Callable, Mapping, Sequence, List, Optional, Union, Literal, Tuple
 
-type Funcs[T] = Callable[..., T] | List[Callable[..., T]] | Dict[str, Funcs[T]]
+type Funcs[T] = Callable[..., T] | Sequence[Callable[..., T]] | Mapping[str, Funcs[T]]
 
 
 __version__: str
@@ -10,46 +10,46 @@ __version__: str
 def run[T](
     funcs: Funcs[T],
     *,
-    parsers: Dict[type, Callable[[str], object]] = ..., 
-    short: Optional[Dict[str, str]] = ..., 
+    parsers: Mapping[type, Callable[[str], object]] = ...,
+    short: Optional[Mapping[str, str]] = ...,
     cli_options: Literal["kwonly", "all", "has_default"] = ..., 
     show_defaults: bool = ..., 
     show_types: bool = ..., 
     no_negated_flags: bool = ..., 
     version: Union[str, None, bool] = ..., 
-    argparse_kwargs: Dict[str, object] = ...,
+    argparse_kwargs: Mapping[str, object] = ...,
     intermixed: bool = ..., 
-    argv: Optional[List[str]] = ...,
+    argv: Optional[Sequence[str]] = ...,
 ) -> T: ...
 
 def bind[T](
     funcs: Funcs[T],
     *,
-    parsers: Dict[type, Callable[[str], object]] = ...,
-    short: Optional[Dict[str, str]] = ..., 
+    parsers: Mapping[type, Callable[[str], object]] = ...,
+    short: Optional[Mapping[str, str]] = ...,
     cli_options: Literal["kwonly", "all", "has_default"] = ..., 
     show_defaults: bool = ..., 
     show_types: bool = ..., 
     no_negated_flags: bool = ..., 
     version: Union[str, None, bool] = ..., 
-    argparse_kwargs: Dict[str, object] = ...,
+    argparse_kwargs: Mapping[str, object] = ...,
     intermixed: bool = ..., 
-    argv: Optional[List[str]] = ...,
+    argv: Optional[Sequence[str]] = ...,
 ) -> Callable[[], T]: ...
 
 def bind_known[T](
     funcs: Funcs[T],
     *,
-    parsers: Dict[type, Callable[[str], object]] = ...,
-    short: Optional[Dict[str, str]] = ..., 
+    parsers: Mapping[type, Callable[[str], object]] = ...,
+    short: Optional[Mapping[str, str]] = ...,
     cli_options: Literal["kwonly", "all", "has_default"] = ..., 
     show_defaults: bool = ..., 
     show_types: bool = ..., 
     no_negated_flags: bool = ..., 
     version: Union[str, None, bool] = ..., 
-    argparse_kwargs: Dict[str, object] = ...,
+    argparse_kwargs: Mapping[str, object] = ...,
     intermixed: bool = ..., 
-    argv: Optional[List[str]] = ...,
+    argv: Optional[Sequence[str]] = ...,
 ) -> Tuple[Callable[[], T], List[str]]: ...
 class Parameter(inspect.Parameter):
     doc: Optional[str]

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -26,7 +26,22 @@ def demo_signature() -> None:
     param_doc: str | None = sig.parameters["value"].doc
 
 
+def demo_run_dict() -> None:
+    """Demonstrate running a mapping of callables.
+
+    This ensures that ``run`` infers and returns the expected type when
+    dispatching to a subcommand.
+    """
+
+    def double(value: int) -> int:
+        return value * 2
+
+    funcs = {"double": double}
+    result: int = run(funcs, argv=["double", "3"])
+
+
 if __name__ == "__main__":
     demo_bind()
     demo_signature()
+    demo_run_dict()
     res: int = run(main)


### PR DESCRIPTION
## Summary
- make Funcs use `Sequence` and `Mapping`
- type `argv` as `Sequence[str]`
- add mapping example to test script

## Testing
- `uv run mypy`
- `uv run python tests/test_script.py 42 --times 1`


------
https://chatgpt.com/codex/tasks/task_e_689dd2b9eba4832893b900c3f65dcd9d